### PR TITLE
Fix home page signup link

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -11,7 +11,7 @@ const Home = () => {
         Track, manage, and show off your personalized Pokémon collections – from vintage first editions to the latest Scarlet & Violet sets.
       </p>
       <Link
-        to="/signup"
+        to="/login"
         className="bg-indigo-600 hover:bg-indigo-700 text-white px-6 py-3 rounded-full text-lg font-semibold shadow-lg"
       >
         Get Started


### PR DESCRIPTION
## Summary
- fix Home page CTA link destination to `/login`
- ensure Home.jsx ends with a newline

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684795499294832e9612b753527b3509